### PR TITLE
JSFUNIT-287 Fix tests

### DIFF
--- a/jboss-jsfunit-core/src/main/java/org/jboss/jsfunit/framework/FaceletsErrorPageException.java
+++ b/jboss-jsfunit-core/src/main/java/org/jboss/jsfunit/framework/FaceletsErrorPageException.java
@@ -52,6 +52,7 @@ public class FaceletsErrorPageException extends RuntimeException
     */
    public static boolean isFaceletsErrorPage(WebResponse response)
    {
+      if (response == null) return false;
       String responseBody = response.getContentAsString();
       if (responseBody == null) return false;
       

--- a/jboss-jsfunit-core/src/main/java/org/jboss/jsfunit/jsfsession/JSFServerSession.java
+++ b/jboss-jsfunit-core/src/main/java/org/jboss/jsfunit/jsfsession/JSFServerSession.java
@@ -132,10 +132,11 @@ public class JSFServerSession implements RequestListener
    public Object getManagedBeanValue(String elExpression)
    {
       FacesContext facesContext = getFacesContext();
+      ExternalContext extContext = facesContext.getExternalContext();
       
       try
       {
-         setELRunning(true, facesContext.getExternalContext());
+         setELRunning(true, extContext);
          return facesContext.getApplication()
                             .createValueBinding(elExpression)
                             .getValue(facesContext);
@@ -157,7 +158,7 @@ public class JSFServerSession implements RequestListener
       }
       finally
       {
-         setELRunning(false, facesContext.getExternalContext());
+         setELRunning(false, extContext);
       }
    }
    

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-ajax4jsf/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-ajax4jsf/pom.xml
@@ -231,6 +231,17 @@
       </build>
     </profile>
 
+    <profile>
+       <id>mojarra1.2</id>
+      <dependencies>
+         <dependency>
+           <groupId>javax.faces</groupId>
+           <artifactId>jsf-api</artifactId>
+           <scope>compile</scope>
+           <version>1.2_13</version>
+        </dependency>    
+      </dependencies>
+    </profile>
 
   </profiles>
 

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-ajax4jsf/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-ajax4jsf/pom.xml
@@ -275,6 +275,7 @@
     <dependency>
         <groupId>javax.faces</groupId>
         <artifactId>jsf-api</artifactId>
+        <scope>provided</scope>
 	</dependency>
     
   </dependencies>

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-jsfunit/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-jsfunit/pom.xml
@@ -88,6 +88,14 @@
          <jsfMajorVersion>1</jsfMajorVersion>
          <jsfMinorVersion>2</jsfMinorVersion>
       </properties>
+      <dependencies>
+         <dependency>
+           <groupId>javax.faces</groupId>
+           <artifactId>jsf-api</artifactId>
+           <scope>compile</scope>
+           <version>1.2_13</version>
+        </dependency>    
+      </dependencies>
     </profile>
     
     <profile>

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-jsfunit/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-jsfunit/pom.xml
@@ -190,6 +190,7 @@
      <dependency>
         <groupId>javax.faces</groupId>
         <artifactId>jsf-api</artifactId>
+        <scope>provided</scope>
      </dependency>
     
   </dependencies>      

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-pathmapped/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-pathmapped/pom.xml
@@ -107,6 +107,22 @@
       </build>
     </profile>
 
+    <profile>
+       <id>mojarra1.2</id>
+       <properties>
+         <jsfMajorVersion>1</jsfMajorVersion>
+         <jsfMinorVersion>2</jsfMinorVersion>
+      </properties>
+      <dependencies>
+         <dependency>
+           <groupId>javax.faces</groupId>
+           <artifactId>jsf-api</artifactId>
+           <scope>compile</scope>
+           <version>1.2_13</version>
+        </dependency>    
+      </dependencies>
+    </profile>
+    
   </profiles>
   
   <dependencies>

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-pathmapped/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-pathmapped/pom.xml
@@ -129,6 +129,7 @@
      <dependency>
         <groupId>javax.faces</groupId>
         <artifactId>jsf-api</artifactId>
+        <scope>provided</scope>
      </dependency>
   </dependencies>      
 

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-webapp/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/jboss-jsfunit-examples-hellojsf-webapp/pom.xml
@@ -28,6 +28,7 @@
       <dependency>
         <groupId>javax.faces</groupId>
         <artifactId>jsf-api</artifactId>
+        <scope>provided</scope>
        </dependency>
    </dependencies>
 

--- a/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/pom.xml
+++ b/jboss-jsfunit-examples/jboss-jsfunit-examples-hellojsf/pom.xml
@@ -37,12 +37,12 @@
        <artifactId>servlet-api</artifactId>
        <scope>provided</scope>
     </dependency>
-    <!--
+    
     <dependency>
       <groupId>javax.faces</groupId>
       <artifactId>jsf-api</artifactId>
       <scope>provided</scope>
-    </dependency> -->
+    </dependency>
   </dependencies>
     
 </project>


### PR DESCRIPTION
This fixes most of the Cactus/Cargo tests.  The only failures now in those tests are with the RichFaces tests when run on JBoss AS 4.2 and AS6.x.  Jetty, Tomcat 5, Tomcat 6, and JBoss AS5.x pass at 100%.
